### PR TITLE
Fix typos and add basic tests

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -20,11 +20,12 @@ Desarrollar macros y herramientas de automatización aplicadas a entornos técni
 
 ```bash
 ProjectAutomateSJL/
-├── macros/           # Módulos .bas con código VBA versionado
+├── Macros/           # Módulos .bas con código VBA versionado
 ├── excel/            # Plantillas de trabajo en Excel (próximamente)
 ├── autocad/          # Archivos DWG y recursos de prueba (próximamente)
-├── docs/             # Documentación técnica y flujos de trabajo
+├── Docs/             # Documentación técnica y flujos de trabajo
 └── README.md         # Este archivo (manual del usuario - versión preliminar)
+```
 ---
 
 ## 📖 Contenido del manual del usuario (en desarrollo)
@@ -43,7 +44,7 @@ Este README funcionará como manual oficial para el uso de las automatizaciones 
    - Ubicación de archivos en la PC
 5. 🧠 Descripción de funciones y rutinas
    - ExtraerAtributosBloqueInstrumentos()
-   - CompletarCamposAutomaticos()
+   - CompletarSenalesYUnidades()
 6. 🧪 Ejecución de la macro paso a paso
    - Qué hojas necesita
    - Qué archivos DWG debe tener cargados
@@ -54,4 +55,13 @@ Este README funcionará como manual oficial para el uso de las automatizaciones 
 10. 📬 Contacto o contribución (si aplica en algún momento)
 
 > ⚠️ Este índice se completará cuando se cierre la primera versión operativa y estable.
+
+
+### ✅ Ejecución de pruebas
+
+Para correr las pruebas automáticas ejecuta:
+
+```bash
+python -m unittest discover -s tests
+```
 

--- a/Macros/mod_InstrumentacionAutomatica.bas
+++ b/Macros/mod_InstrumentacionAutomatica.bas
@@ -18,7 +18,7 @@ Sub ExtraerAtributosBloqueInstrumentos()
     Dim hojaNotasRef As Worksheet
 
     ' === VARIABLES DE CONTROL Y PROCESO ===
-    Dim valorFuncion As String
+    Dim valorFunction As String
     Dim valorTag As String
     Dim filaExcel As Long
     Dim tagTracking As Object
@@ -46,7 +46,7 @@ Sub ExtraerAtributosBloqueInstrumentos()
 
 Set wb = ActiveWorkbook
 Set hojaLI = wb.Worksheets("LI")
-Set hojaCar = wb.Worksheets("Car�tula")
+Set hojaCar = wb.Worksheets("Carátula")
 Set hojaNotasRef = wb.Worksheets("Notas - Referencias")
 
 rutaDocs = Application.GetOpenFilename("Excel Files (*.xlsx), *.xlsx", , "Selecciona LISTA DE DOCUMENTOS")

--- a/tests/test_mod_InstrumentacionAutomatica.py
+++ b/tests/test_mod_InstrumentacionAutomatica.py
@@ -1,0 +1,22 @@
+import unittest
+from pathlib import Path
+
+class TestModInstrumentacionAutomatica(unittest.TestCase):
+    def setUp(self):
+        root = Path(__file__).resolve().parents[1]
+        bas_path = root / 'Macros' / 'mod_InstrumentacionAutomatica.bas'
+        with bas_path.open(encoding='latin-1') as f:
+            self.content = f.read()
+
+    def test_contains_function_definitions(self):
+        self.assertIn('Sub ExtraerAtributosBloqueInstrumentos', self.content)
+        self.assertIn('Sub CompletarSenalesYUnidades', self.content)
+
+    def test_variable_naming(self):
+        # Variable should usar el nombre basado en FUNCTION
+        self.assertIn('valorFunction', self.content)
+        self.assertNotIn('valorFuncion', self.content)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- fix worksheet name `Carátula`
- rename `valorFuncion` variable to `valorFunction`
- update README formatting and function list
- document how to run unit tests
- add simple test suite for the VBA module

## Testing
- `python3 -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68642a03a954832c9705d4203903289a